### PR TITLE
アンケート詳細のUIを修正、投票詳細画面を追加、投票関連を微修正

### DIFF
--- a/src/karakuchi_room/templates/karakuchi_room/surveys_detail.html
+++ b/src/karakuchi_room/templates/karakuchi_room/surveys_detail.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <!-- ナビゲーションバー仮 -->
+    {% comment %} ナビゲーションバー仮 {% endcomment %}
     <nav>
         <div class="container">
             <div class="d-flex justify-content-between align-items-center py-3">
@@ -30,9 +30,7 @@
         <!-- ナビゲーションバー仮 -->
     </nav>
     <div class="container">
-        {% comment %}
-        <!-- 実装時、{% block content}{% endblock content %}外はbase.htmlから参照する -->
-        {% endcomment %}
+        {% comment %}実装時、{% block content}{% endblock content %}外はbase.htmlから参照する{% endcomment %}
         {% block content %}
         <div class="header">
             <h2>{{ survey.title }}</h2>
@@ -47,10 +45,10 @@
             {% endcomment %}
         </div>
         <div class="row mb-2">
-        <!--   <span class="col-auto">{{ survey.start_at }}</span> -->
+            {% comment %} <span class="col-auto">{{ survey.start_at }}</span> {% endcomment %}
             <span class="col-auto">期限: {{ survey.end_at }}まで</span>
         </div>
-        <!-- アンケート作成者本人の場合 -->
+        {% comment %} アンケート作成者本人の場合 {% endcomment %}
         <div class="d-flex justify-content-between">
             {% comment %}
             <div>
@@ -66,30 +64,33 @@
                 <a href="{% url 'survey-delete' survey.pk %}">削除</a>
             </div>
         </div>
-        <!-- アンケート作成者で本人ではない場合 -->
-        <!-- <div class="d-flex justify-content-end">
+        {% comment %} アンケート作成者で本人ではない場合 {% endcomment %}
+        {% comment %} <div class="d-flex justify-content-end">
             <span class="col-auto">2026/1/20</span>
-        </div> -->
+        </div> {% endcomment %}
         <div class="discription border border-secondary p-2 mt-3">
             <p>{{ survey.description }}</p>
         </div>
-        <!-- 円グラフ chart.jsで実装する-->
+        {% comment %} 円グラフ chart.jsで実装する {% endcomment %}
         <div class="m-3 p-3">
             <p>（仮）ここにchart.jsで円グラフを表示</p>
             <canvas id="myChart"></canvas>
         </div>
+        {% comment %} ユーザーが投票している場合、表示 {% endcomment %}
+        <div>
+            <p>あなたは投票済みです！<a href="">投票詳細へ</a></p>
+        </div>
+        {% comment %} ユーザーが投票している場合、表示 ここまで{% endcomment %}
         <div class="comment-list">
             <div>
                 <h4>みんなのコメント</h4>
             </div>
             <ul class="list-unstyled">
-                {% comment %}
-                <!-- {{ for コメント表示 }} -->
-                {% endcomment %}
+                {% comment %}{{ for コメント表示 }}{% endcomment %}
                 <li>
                     <div class="card p-3">
                         <div class="d-flex">
-                            <!-- 円グラフの凡例に色をあわせる -->
+                            {% comment %} 円グラフの凡例に色をあわせる {% endcomment %}
                             <div class="text-primary me-2">
                                 <span>■</span>
                             </div>
@@ -97,25 +98,15 @@
                                 <p>操作中にエラーで落ちてしまいましたニャン♪😿公開前にチェックしておくべき事項だと思いますニャン♪</p>
                             </div>
                         </div>
-                        <!-- 投票者本人の場合 -->
-                        <div class="d-flex justify-content-between">
-                            <div>
-                                <a class="me-4">編集</a>
-                                <a href="">削除</a>
-                            </div>
+                        {% comment %} 投票者本人の場合  {% endcomment %}
+                        <div class="d-flex justify-content-end">
                             <div>
                                 <span class="col-auto">{{ survey.end_at }}</span>
                             </div>
                         </div>
-                        <!-- 投票者で本人ではない場合 -->
-                        <!-- <div class="d-flex justify-content-end">
-                            <span class="col-auto">2026/1/20</span>
-                        </div> -->
                     </div>
                 </li>
-                {% comment %}
-                <!-- {{ endfor リスト表示}} -->
-                {% endcomment %}  
+                {% comment %}{{ endfor リスト表示}}{% endcomment %}  
             </ul>
         </div>
         {% endblock content %}

--- a/src/karakuchi_room/templates/karakuchi_room/votes_create.html
+++ b/src/karakuchi_room/templates/karakuchi_room/votes_create.html
@@ -86,12 +86,9 @@
                 <button type="submit" class="btn btn-success px-5">投票！</button>
             </div>
         </form>
-    </div>
-    <div class="text-center my-5">
-        <a href="">投票作成をキャンセルして戻る</a>
-    </div>
-    </div>
-    </div>
+        <div class="text-center my-5">
+            <a href="">投票作成をキャンセルして戻る</a>
+        </div>
     {% comment %} {% endblock content %} {% endcomment %}
     </div>
     <footer class="text-center p-3">

--- a/src/karakuchi_room/templates/karakuchi_room/votes_detail.html
+++ b/src/karakuchi_room/templates/karakuchi_room/votes_detail.html
@@ -1,0 +1,102 @@
+    <!DOCTYPE html>
+    <html lang="ja">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Document</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
+            integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+    </head>
+
+    <body>
+        {% comment %} ナビゲーションバー仮 {% endcomment %}
+        <nav>
+            <div class="container">
+                <div class="d-flex justify-content-between align-items-center py-3">
+                    <div class="col">
+                        <a href=""><img width="100" src="image/logo.png" alt="鷹の爪親方の辛口部屋のロゴ"></a>
+                    </div>
+                    <div class="col-auto">
+                        <div class="d-flex align-items-center">
+                            <a class="me-3" href="">アンケート作成</a>
+                            <a class="me-3" href="">アンケート一覧
+                                <a class=" me-3" href="">ユーザー情報</a>
+                                <a class="btn btn-outline-primary" href="">ログアウト</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% comment %} ナビゲーションバー仮 {% endcomment %}
+        </nav>
+        <div class="container">
+            {% comment %} 実装時、{% block content}{% endblock content %}外はbase.htmlから参照する {% endcomment %}
+            {% comment %} {% block content %} {% endcomment %}
+            <div class="header">
+                <h2>投票詳細</h2>
+            </div>
+            <div class="survey-title my-3">
+                <h2>私のポートフォリオ、ぶっちゃけどうですか？ </h2>
+            </div>
+            <div class="deadline my-2">
+                <span>投票期限：2025/1/29</span>
+            </div>
+            <div class="discription border border-secondary p-2 my-3">
+                <p>ポートフォリオのurlです。********************製作期間は1か月であることが自慢です。</p>
+            </div>
+            <div class="h4 mt-5">
+                <p>あなたはどう思う？</p>
+            </div>
+            {% comment %} 選択肢をradioボタンで選択 {% endcomment %}
+            <div class="select-radio p-3">
+                {% comment %} radioボタンをfor文で繰り返し表示 {% endcomment %}
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="option1" id="option1" value="1" disabled>
+                    <span>
+                        いいと思う！
+                    </span>
+                </div>
+                {% comment %} radioボタンをfor文で繰り返し表示 ここまで {% endcomment %}
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="option2" id="option2" value="2" disabled>
+                    <span>
+                        改善の余地あり
+                    </span>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="option3" id="option3" value="3" disabled>
+                    <span>
+                        その他
+                    </span>
+                </div>
+            </div>
+            {% comment %} 選択肢をradioボタンで選択 ここまで{% endcomment %}
+            <div class="comment mt-5 mb-4">
+                <p class="h4">選択肢を選んだ理由（任意）</p>
+                <div class="discription border border-secondary p-2 mt-3">
+                    <p>理由を入力</p>
+                </div>
+            </div>
+            {% comment %} 追加機能 文章加工機能{% endcomment %}
+            {% comment %} <div class="edit-button row mb-5">
+                <button class="btn btn-secondary col-md m-3">甘口文章に変換</button>
+                <button class="btn btn-secondary col-md m-3">文章の癖を減らす</button>
+            </div> {% endcomment %}
+            {% comment %} 追加機能 文章加工機能ここまで{% endcomment %}
+            <div class="edit-btn text-center mb-5">
+                <a href="" class="btn btn-success px-5">投票内容を変更！</a>
+            </div>
+            <div class="delete-btn text-center">
+                <a href="" class="btn btn-danger px-5">投票内容を削除！</a>
+            </div>
+            <div class="text-center my-5">
+                <a href="">アンケート詳細に戻る</a>
+            </div>
+            {% comment %} {% endblock content %} {% endcomment %}
+        </div>
+        <footer class="text-center p-3">
+            <span class="text-muted"> &copy; Team C 2025 Autumn</span>
+        </footer>
+    </body>
+
+    </html>

--- a/src/karakuchi_room/templates/karakuchi_room/votes_edit.html
+++ b/src/karakuchi_room/templates/karakuchi_room/votes_edit.html
@@ -52,20 +52,20 @@
             <div class="select-radio p-3">
                 {% comment %} radioボタンをfor文で繰り返し表示 {% endcomment %}
                 <div class="form-check">
-                    <input class="form-check-input" type="radio" name="option1" id="option1" value="1">
+                    <input class="form-check-input" type="radio" name="option" id="option1" value="1">
                     <label class="form-check-label" for="option1">
                         いいと思う！
                     </label>
                 </div>
                 {% comment %} radioボタンをfor文で繰り返し表示 ここまで {% endcomment %}
                 <div class="form-check">
-                    <input class="form-check-input" type="radio" name="option2" id="option2" value="2">
+                    <input class="form-check-input" type="radio" name="option" id="option2" value="2">
                     <label class="form-check-label" for="option2">
                         改善の余地あり
                     </label>
                 </div>
                 <div class="form-check">
-                    <input class="form-check-input" type="radio" name="option3" id="option3" value="3">
+                    <input class="form-check-input" type="radio" name="option" id="option3" value="3">
                     <label class="form-check-label" for="option3">
                         その他
                     </label>
@@ -86,13 +86,10 @@
                 <button type="submit" class="btn btn-success px-5">投票内容を変更！</button>
             </div>
         </form>
-    </div>
-    <div class="text-center my-5">
-        <a href="">投票編集をキャンセルして戻る</a>
-    </div>
-    </div>
-    </div>
-    {% comment %} {% endblock content %} {% endcomment %}
+        <div class="text-center my-5">
+            <a href="">投票編集をキャンセルして戻る</a>
+        </div>
+        {% comment %} {% endblock content %} {% endcomment %}
     </div>
     <footer class="text-center p-3">
         <span class="text-muted"> &copy; Team C 2025 Autumn</span>


### PR DESCRIPTION
# 🚀 Pull Request 概要

## 📝 変更内容
<!-- このPRでどのような変更を行ったのか簡潔に説明してください -->
- [x] 新機能の追加
- [x] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明を記載）

### 詳細
<!-- 実際に変更した箇所・理由などを記載 -->
【修正】
　UI変更に伴い、アンケート詳細画面を修正、投票者本人の場合に表示されるコメント欄内の編集、削除のリンクを削除
　替わりに投票済みの場合に投票詳細画面へ遷移するリンクが表示されるよう側だけ作成

【機能追加】
　投票詳細画面を追加

【微修正】
- アンケート詳細画面のコメントをDjango HTMLの記述に統一　（ブラウザ上からの見た目の変化なし）
- 投票作成画面、投票編集画面の不要なタグを削除、インデントずれを解消（ブラウザ上からの見た目の変化なし）
- 投票作成画面のラジオボタンを微修正（ブラウザ上からの見た目の変化なし）
---

## 🔍 関連Issue
<!--Issuesタブから関連するisuueのリンクを共有する。-->
https://github.com/autumn-hackathon-c/Karakuchi-room-of-Taka-no-Tsume-Oyakata/issues/48

---

## ✅ チェックリスト
<!-- 該当する項目にチェック(x)を入れてください -->
### 必須項目
- [x] 挙動確認をしたか
- [x] コードが正しく動作するか
- [ ] Linter / Formatter を実行済みか

### 任意項目
- [ ] テストを実行し、全て成功したか
- [ ] 不要なログ・コメントを削除したか
- [ ] 関連ドキュメントを更新したか（READMEなど）

---

## 📸 スクリーンショット（UI変更がある場合）
<!-- UI変更がある場合はスクリーンショットを添付 -->
【アンケート詳細画面（surveys_detail.html）本プロジェクトのDjangoサーバーからブラウザに表示したもの】
<img width="688" height="405" alt="image" src="https://github.com/user-attachments/assets/b35b7843-1fda-4ffc-a03f-4bc4ec746ea2" />


【投票詳細画面（votes_detail.html）仮で作ったDjangoサーバーからブラウザに表示したもの】
<img width="523" height="375" alt="image" src="https://github.com/user-attachments/assets/89ff2073-207d-4e71-a5de-9f333c03ac0e" />




---

## 💬 備考
<!-- レビューアーに伝えたい補足事項を記載 -->
---

## 👥 レビュアーへの依頼
<!-- レビューを依頼したい人をメンション -->
@iwaki-toshiyuki @Shiho-F 