### PR TITLE
論理削除及びカスケードの設定

### DIFF
--- a/src/karakuchi_room/migrations/0004_alter_option_survey_alter_survey_user_and_more.py
+++ b/src/karakuchi_room/migrations/0004_alter_option_survey_alter_survey_user_and_more.py
@@ -6,45 +6,85 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('karakuchi_room', '0003_rename_is_admin_user_is_staff'),
+        ("karakuchi_room", "0003_rename_is_admin_user_is_staff"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='option',
-            name='survey',
-            field=models.ForeignKey(db_column='survey_id', on_delete=django.db.models.deletion.CASCADE, related_name='options', to='karakuchi_room.survey', verbose_name='アンケートID'),
+            model_name="option",
+            name="survey",
+            field=models.ForeignKey(
+                db_column="survey_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="options",
+                to="karakuchi_room.survey",
+                verbose_name="アンケートID",
+            ),
         ),
         migrations.AlterField(
-            model_name='survey',
-            name='user',
-            field=models.ForeignKey(db_column='user_id', on_delete=django.db.models.deletion.CASCADE, related_name='surveys', to=settings.AUTH_USER_MODEL),
+            model_name="survey",
+            name="user",
+            field=models.ForeignKey(
+                db_column="user_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="surveys",
+                to=settings.AUTH_USER_MODEL,
+            ),
         ),
         migrations.AlterField(
-            model_name='tagsurvey',
-            name='survey',
-            field=models.ForeignKey(db_column='survey_id', on_delete=django.db.models.deletion.CASCADE, related_name='tag_surveys', to='karakuchi_room.survey', verbose_name='アンケートID'),
+            model_name="tagsurvey",
+            name="survey",
+            field=models.ForeignKey(
+                db_column="survey_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="tag_surveys",
+                to="karakuchi_room.survey",
+                verbose_name="アンケートID",
+            ),
         ),
         migrations.AlterField(
-            model_name='tagsurvey',
-            name='tag',
-            field=models.ForeignKey(db_column='tag_id', on_delete=django.db.models.deletion.CASCADE, related_name='tag_surveys', to='karakuchi_room.tag', verbose_name='タグID'),
+            model_name="tagsurvey",
+            name="tag",
+            field=models.ForeignKey(
+                db_column="tag_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="tag_surveys",
+                to="karakuchi_room.tag",
+                verbose_name="タグID",
+            ),
         ),
         migrations.AlterField(
-            model_name='vote',
-            name='option',
-            field=models.ForeignKey(db_column='option_id', on_delete=django.db.models.deletion.CASCADE, related_name='votes', to='karakuchi_room.option', verbose_name='選択ID'),
+            model_name="vote",
+            name="option",
+            field=models.ForeignKey(
+                db_column="option_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="votes",
+                to="karakuchi_room.option",
+                verbose_name="選択ID",
+            ),
         ),
         migrations.AlterField(
-            model_name='vote',
-            name='survey',
-            field=models.ForeignKey(db_column='survey_id', on_delete=django.db.models.deletion.CASCADE, related_name='votes', to='karakuchi_room.survey', verbose_name='アンケートID'),
+            model_name="vote",
+            name="survey",
+            field=models.ForeignKey(
+                db_column="survey_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="votes",
+                to="karakuchi_room.survey",
+                verbose_name="アンケートID",
+            ),
         ),
         migrations.AlterField(
-            model_name='vote',
-            name='user',
-            field=models.ForeignKey(db_column='user_id', on_delete=django.db.models.deletion.CASCADE, related_name='votes', to=settings.AUTH_USER_MODEL, verbose_name='ユーザーID'),
+            model_name="vote",
+            name="user",
+            field=models.ForeignKey(
+                db_column="user_id",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="votes",
+                to=settings.AUTH_USER_MODEL,
+                verbose_name="ユーザーID",
+            ),
         ),
     ]

--- a/src/karakuchi_room/models.py
+++ b/src/karakuchi_room/models.py
@@ -31,11 +31,11 @@ class SoftDeleteManager(models.Manager):
         return SoftDeleteQuerySet(self.model, using=self._db).filter(is_deleted=False)
 
 
-#  個別オブジェクトの delete() も論理削除に差し替え 
+#  個別オブジェクトの delete() も論理削除に差し替え
 class SoftDeleteModel(models.Model):
     objects = SoftDeleteManager()
     all_objects = SoftDeleteQuerySet.as_manager()
-    
+
     #   この部分は命名を変えると物理削除なるので変更しない。
     def delete(self, using=None, keep_parents=False):
         self.is_deleted = True
@@ -158,7 +158,7 @@ class Survey(SoftDeleteModel):
 
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,  # Userモデル（親）
-        on_delete=models.CASCADE,  
+        on_delete=models.CASCADE,
         related_name="surveys",
         db_column="user_id",
         null=False,


### PR DESCRIPTION
# 🚀 Pull Request 概要

## 📝 変更内容
<!-- このPRでどのような変更を行ったのか簡潔に説明してください -->
- [ ] 新機能の追加
- [ ] バグ修正
- [ ] ドキュメント修正
- [x] リファクタリング
- [ ] その他（説明を記載）

### 詳細
<!-- 実際に変更した箇所・理由などを記載 -->
- 論理削除できるようにmodels.pyを修正

---

## 🔍 関連Issue
<!--Issuesタブから関連するisuueのリンクを共有する。-->
https://github.com/autumn-hackathon-c/Karakuchi-room-of-Taka-no-Tsume-Oyakata/issues/15


---

## ✅ チェックリスト
<!-- 該当する項目にチェック(x)を入れてください -->
### 必須項目
- [x] 挙動確認をしたか
- [x] コードが正しく動作するか
- [x] Linter / Formatter を実行済みか

### 任意項目
- [ ] テストを実行し、全て成功したか
- [ ] 不要なログ・コメントを削除したか
- [ ] 関連ドキュメントを更新したか（READMEなど）

---

## 📸 スクリーンショット（UI変更がある場合）
<!-- UI変更がある場合はスクリーンショットを添付 -->

---

## 💬 備考
<!-- レビューアーに伝えたい補足事項を記載 -->
- 作業中に物理削除になっていることに気づいたので論理削除できるように修正しました。
- on_delete=models.PROTECTからon_delete=models.CASCADEに変更
この設定をしないと子を削除しないと親を削除できない。
 （ex アンケートを削除しないとユーザーを削除できない。）
ちなみに上記設定にして論理削除になっていること確認済み。

---

## 👥 レビュアーへの依頼
<!-- レビューを依頼したい人をメンション -->
@hitomu-1  @Shiho-F 