### PR TITLE
fix: バリデーションエラー時にフォームが再表示される時のフォームの不具合を解消、エラー表示のレイアウト調整

### DIFF
--- a/src/karakuchi_room/templates/karakuchi_room/surveys_create.html
+++ b/src/karakuchi_room/templates/karakuchi_room/surveys_create.html
@@ -24,10 +24,12 @@
             {{ formset.management_form }}
 
             {# バリデーションエラーメッセージ表示 #}
-            {% if formset.non_form_errors %}
-                <div class="alert alert-danger">
-                    {{ formset.non_form_errors }}
-                </div>
+            {% if formset.non_form_errors%}
+            <div class="alert alert-danger">
+                {% for error in formset.non_form_errors %}
+                {{ error }}
+                {% endfor %}
+            </div>
             {% endif %}
 
             <div id="option-container">

--- a/src/karakuchi_room/templates/karakuchi_room/surveys_edit_save_temporary.html
+++ b/src/karakuchi_room/templates/karakuchi_room/surveys_edit_save_temporary.html
@@ -24,10 +24,12 @@
             {{ formset.management_form }}
 
             {# バリデーションエラーメッセージ表示 #}
-            {% if formset.non_form_errors %}
-                <div class="alert alert-danger">
-                    {{ formset.non_form_errors }}
-                </div>
+            {% if  formset.non_form_errors %}
+            <div class="alert alert-danger">
+                {% for error in formset.non_form_errors %}
+                {{ error }}
+                {% endfor %}
+            </div>
             {% endif %}
 
             <div id="option-container">

--- a/src/static/js/form-control.js
+++ b/src/static/js/form-control.js
@@ -6,6 +6,12 @@ document.addEventListener("DOMContentLoaded", function() {
         return;
     }
 
+    // 隠しDELETEフィールド、チェックボックスの初期化
+    document.querySelectorAll("input[name$='-DELETE']").forEach(function(input) {
+    input.checked = false;
+    input.value = "";
+    });
+
     const addBtn = document.querySelector(".add-option");
     const totalFormsInput = document.querySelector("input[name='options-TOTAL_FORMS']");
     const emptyWrapper = document.querySelector("#empty-form-template");


### PR DESCRIPTION
# 🚀 Pull Request 概要

## 📝 変更内容
<!-- このPRでどのような変更を行ったのか簡潔に説明してください -->
- [ ] 新機能の追加
- [x] バグ修正
- [ ] ドキュメント修正
- [ ] リファクタリング
- [ ] その他（説明を記載）

### 詳細
<!-- 実際に変更した箇所・理由などを記載 -->
バリデーションエラー時で画面が再表示される時に、チェックボックスの表示は 外れているのに、隠しフィールドのDELETE フィールド（hidden など）が前回チェックしていた状態を保持してしまっていたため、画面表示時にDELETEフィールドとチェックボックスの初期化をして、両方のチェックを外すようにしました。

また、エラー表示のレイアウトを整えています。

---

## 🔍 関連Issue
<!--Issuesタブから関連するisuueのリンクを共有する。-->
https://github.com/autumn-hackathon-c/Karakuchi-room-of-Taka-no-Tsume-Oyakata/issues/69
https://github.com/autumn-hackathon-c/Karakuchi-room-of-Taka-no-Tsume-Oyakata/issues/89

---

## ✅ チェックリスト
<!-- 該当する項目にチェック(x)を入れてください -->
### 必須項目
- [x] 挙動確認をしたか
- [x] コードが正しく動作するか
- [ ] Linter / Formatter を実行済みか

### 任意項目
- [ ] テストを実行し、全て成功したか
- [ ] 不要なログ・コメントを削除したか
- [ ] 関連ドキュメントを更新したか（READMEなど）

---

## 📸 スクリーンショット（UI変更がある場合）
<!-- UI変更がある場合はスクリーンショットを添付 -->
<img width="1212" height="626" alt="image" src="https://github.com/user-attachments/assets/05622f30-7430-48aa-a679-0b3a5bacf6d3" />

---

## 💬 備考
<!-- レビューアーに伝えたい補足事項を記載 -->

---

## 👥 レビュアーへの依頼
<!-- レビューを依頼したい人をメンション -->
@iwaki-toshiyuki @Shiho-F 